### PR TITLE
Client - check for duplicate email address before new user registration

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import {
-  check_for_duplicate_username,
+  check_for_duplicate_email,
   register_user,
 } from "../../managers/userManager"
 
@@ -48,13 +48,13 @@ export const Register = () => {
     if (missingValues.length !== 0) {
       window.alert("Please fill out all fields before clicking Register.")
     } else {
-      check_for_duplicate_username(userCopy["username"]).then((result) => {
-        if (result["username_exists"] === false) {
+      check_for_duplicate_email(userCopy["email"]).then((result) => {
+        if (result["valid"] === false) {
           register_user(userCopy).then(() => {
             navigate("/")
           })
         } else {
-          window.alert("That username is taken. Please choose a new one.")
+          window.alert("Your email has already been registered.")
         }
       })
     }

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -1,6 +1,9 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { register_user } from "../../managers/userManager"
+import {
+  check_for_duplicate_username,
+  register_user,
+} from "../../managers/userManager"
 
 export const Register = () => {
   const navigate = useNavigate()
@@ -45,8 +48,14 @@ export const Register = () => {
     if (missingValues.length !== 0) {
       window.alert("Please fill out all fields before clicking Register.")
     } else {
-      register_user(userCopy).then(() => {
-        navigate("/")
+      check_for_duplicate_username(userCopy["username"]).then((result) => {
+        if (result["username_exists"] === false) {
+          register_user(userCopy).then(() => {
+            navigate("/")
+          })
+        } else {
+          window.alert("That username is taken. Please choose a new one.")
+        }
       })
     }
   }

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -49,7 +49,7 @@ export const Register = () => {
       window.alert("Please fill out all fields before clicking Register.")
     } else {
       check_for_duplicate_email(userCopy["email"]).then((result) => {
-        if (result["valid"] === false) {
+        if (result["email_exists"] === false) {
           register_user(userCopy).then(() => {
             navigate("/")
           })

--- a/src/managers/userManager.js
+++ b/src/managers/userManager.js
@@ -11,8 +11,8 @@ export const register_user = async (user) => {
   return await response.json()
 }
 
-export const check_for_duplicate_username = async (username) => {
-  const response = await fetch(`${apiURL}/users?username=${username}`)
-  const duplicate_results = await response.json()
-  return duplicate_results
+export const check_for_duplicate_email = async (email) => {
+  const response = await fetch(`${apiURL}/users?email=${email}`)
+  const token = await response.json()
+  return token
 }

--- a/src/managers/userManager.js
+++ b/src/managers/userManager.js
@@ -10,3 +10,9 @@ export const register_user = async (user) => {
   const response = await fetch(`${apiURL}/users`, postOptions)
   return await response.json()
 }
+
+export const check_for_duplicate_username = async (username) => {
+  const response = await fetch(`${apiURL}/users?username=${username}`)
+  const duplicate_results = await response.json()
+  return duplicate_results
+}


### PR DESCRIPTION
This PR adds functionality to check whether an email address is already in the database before registering a new user to ensure that each user in the system has a unique email address. If n email address already exists, the user will receive a window alert indicating that the email address is already taken, and the user will not be posted to the database.

Addresses #48 

To Test:
1. Start up the api in the debugger, and run npm start while checked out on this branch of the client repo.
2. Navigate to localhost:3000/register in your browser.
3. Fill out all fields of the form with a test user details and click Register. Verify that the user was added to your version of db.sqlite3. 
4. Go back to localhost:3000/register and try to register a new user, using the same email address that was used in step 3. Click Register. You should receive a window alert pop-up with an error indicating that the email address has already been registered.